### PR TITLE
Output declarations in sorted order by name.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -219,7 +219,17 @@ func (gen *Generator) WriteTypedefs(wr io.Writer) int {
 		writeSpace(wr, 1)
 		count++
 	}
-	for tag, decl := range gen.tr.TagMap() {
+
+	decls := []*tl.CDecl{}
+	for _, decl := range gen.tr.TagMap() {
+		decls = append(decls, decl)
+	}
+	sort.Slice(decls, func(i int, j int) bool {
+		return decls[i].Name < decls[j].Name
+	})
+
+	for _, decl := range decls {
+		tag := decl.Name
 		switch decl.Spec.Kind() {
 		case tl.StructKind, tl.OpaqueStructKind:
 			if seenStructTags[tag] {


### PR DESCRIPTION
Using a [specially written tool for the problem](https://github.com/pwaller/cartographer/blob/master/main.go), I inspected all loops over maps (all 6 of them), and spotted the one that was causing a problem.

The file output is still not deterministic because of the timestamp in the file.

May I suggest removing the timestamp? Then the output will be fully determinstic and diff can be used to determine file equality.