### PR TITLE
Pass function pointer instead of &parameter

### DIFF
--- a/generator/gen_bindings.go
+++ b/generator/gen_bindings.go
@@ -508,7 +508,7 @@ func (gen *Generator) proxyArgFromGo(memTip tl.Tip, name string,
 			if goSpec.Pointers == 0 {
 				ref = "&"
 			}
-			proxy = fmt.Sprintf("(*[0]byte)(unsafe.Pointer(%s%s)), cgoAllocsUnknown", ref, name)
+			proxy = fmt.Sprintf("*(**[0]byte)(unsafe.Pointer(%s%s)), cgoAllocsUnknown", ref, name)
 			return
 		} else if goSpec.Pointers == 0 {
 			ref = "&"


### PR DESCRIPTION
Before this commit, a pointer to the stack was passed as the function
pointer. If you passed `nil` as a function pointer, for example, a
pointer to the stack was being passed.

This fix is not thorough and I don't actually want to call a CB, so I
have not checked that it works for that use case. I have not dived in to
discover if there is a better way to make this work, I could use a hand
here improving this fix.

I note that there exists a function pointer type (`CB` below), which has
a `PassRef`/`PassValue` methods. Maybe those should be called?

Before:

```
func F(cb CB) {
	cb, _ := (*[0]byte)(unsafe.Pointer(&cb)), cgoAllocsUnknown
	C.cfunc(cb)
}
```

After:

```
func F(cb CB) {
	cb, _ := *(**[0]byte)(unsafe.Pointer(&cb)), cgoAllocsUnknown
	C.cfunc(cb)
}
```