### PR TITLE
fix parameter names for the __GNUC_PREREQ macro

### DIFF
--- a/parser/predefined.go
+++ b/parser/predefined.go
@@ -50,7 +50,7 @@ var basePredefines = `
 #define __STDC_VERSION__ 199901L
 #define __STDC__ 1
 #define __GNUC__ 4
-#define __GNUC_PREREQ(x,y) 0
+#define __GNUC_PREREQ(maj,min) 0
 #define __POSIX_C_DEPRECATED(ver)
 
 #define __FLT_MIN__ 0


### PR DESCRIPTION
The parameter names for this macro didn't match the ones in the existing GNU sources, resulting in an error processing a .yml file that worked with previous versions of c-for-go. (The error is: "cannot redefine macro __GNUC_PREREQ: argument names differ"). This changes the argument names to match those in the gnuc header files.