### PR TITLE
Normalize pointers for callback function return specs

### DIFF
--- a/generator/gen_callbacks.go
+++ b/generator/gen_callbacks.go
@@ -42,7 +42,7 @@ func (gen *Generator) getCallbackHelpers(goFuncName, cFuncName string, spec tl.C
 	buf := new(bytes.Buffer)
 	retSpec := "void"
 	if funcSpec.Return != nil {
-		retSpec = funcSpec.Return.String()
+		retSpec = gen.tr.NormalizeSpecPointers(funcSpec.Return).String()
 	}
 	fmt.Fprintf(buf, "%s %s(%s);", retSpec, cbCName, paramList)
 	helpers = append(helpers, &Helper{


### PR DESCRIPTION
This fixes an issue I've ran into with [https://github.com/facebook/yoga](Yoga) when a callback helper is created for [cloneNodeCallback](https://github.com/facebook/yoga/blob/master/yoga/YGConfig.h#L19)/[YGCloneNodeFunc](https://github.com/facebook/yoga/blob/5e3ffb39a2acb05d4fe93d04f5ae4058c047f6b1/yoga/Yoga.h#L65).

The signature in `types.go` is generated correctly as
```go
type YGCloneNodeFunc func(oldNode YGNodeRef, owner YGNodeRef, childIndex int32) YGNodeRef
```

But the return type in `cgo_helpers.c` contains an extra pointer from `YGNodeRef`'s underlying `*YGNode` type
```c
YGNodeRef* YGCloneNodeFunc_7c7b6182(YGNodeRef oldNode, YGNodeRef owner, int childIndex) {
	return cloneNodeFunc7C7B6182(oldNode, owner, childIndex);
}
