### PR TITLE
Change Data in the slice/string headers to unsafe.Pointer

### DIFF
--- a/generator/gen_callbacks.go
+++ b/generator/gen_callbacks.go
@@ -269,7 +269,7 @@ func (gen *Generator) proxyCallbackArgToGo(memTip tl.Tip, varName, ptrName strin
 		postfix := gen.randPostfix()
 		fmt.Fprintf(buf, "var %s %s\n", varName, goSpec)
 		fmt.Fprintf(buf, "hx%2x := (*sliceHeader)(unsafe.Pointer(&%s))\n", postfix, varName)
-		fmt.Fprintf(buf, "hx%2x.Data = uintptr(unsafe.Pointer(%s))\n", postfix, ptrName)
+		fmt.Fprintf(buf, "hx%2x.Data = unsafe.Pointer(%s)\n", postfix, ptrName)
 		fmt.Fprintf(buf, "hx%2x.Cap = %s\n", postfix, gen.maxMem)
 		fmt.Fprintf(buf, "// hx%2x.Len = ?\n", postfix)
 		proxy = buf.String()


### PR DESCRIPTION
Similar to the "safe" versions of `sliceHeader` and `stringHeader` in [reflect/value.go](https://golang.org/src/reflect/value.go?s=53122:53174#L1783).

I could be wrong, but I believe this fixes [(6) Conversion of a reflect.SliceHeader or reflect.StringHeader Data field to or from Pointer.](https://golang.org/pkg/unsafe/#Pointer) (it removes the `go vet` warning at least).