### PR TITLE
Allow for object oriented c bindings

### DIFF
--- a/generator/gen_declares.go
+++ b/generator/gen_declares.go
@@ -83,7 +83,9 @@ func (gen *Generator) writeFunctionDeclaration(wr io.Writer, decl *tl.CDecl,
 	}
 	fmt.Fprintf(wr, "// %s function as declared in %s\n", goName,
 		gen.tr.SrcLocation(tl.TargetFunction, decl.Name, decl.Pos))
-	fmt.Fprintf(wr, "func %s", goName)
+	fmt.Fprintf(wr, "func")
+	gen.writeInstanceObjectParam(wr, cName, decl.Spec)
+	fmt.Fprintf(wr, " %s", goName)
 	gen.writeFunctionParams(wr, cName, decl.Spec)
 	if len(returnRef) > 0 {
 		fmt.Fprintf(wr, " %s", returnRef)

--- a/translator/model_go_type.go
+++ b/translator/model_go_type.go
@@ -26,7 +26,7 @@ func (spec *GoTypeSpec) splitPointers(ptrTip Tip, n uint8) {
 	case TipPtrRef:
 		spec.Slices = spec.Slices + n - 1
 		spec.Pointers++
-	case TipPtrSRef:
+	case TipPtrSRef, TipPtrInst:
 		spec.Pointers += n
 	case TipPtrArr:
 		spec.Slices += n

--- a/translator/rules.go
+++ b/translator/rules.go
@@ -89,6 +89,7 @@ const (
 	TipPtrSRef   Tip = "sref"
 	TipPtrRef    Tip = "ref"
 	TipPtrArr    Tip = "arr"
+	TipPtrInst   Tip = "inst"
 	TipMemRaw    Tip = "raw"
 	TipTypeNamed Tip = "named"
 	TipTypePlain Tip = "plain"
@@ -106,7 +107,7 @@ const (
 
 func (t Tip) Kind() TipKind {
 	switch t {
-	case TipPtrArr, TipPtrRef, TipPtrSRef:
+	case TipPtrArr, TipPtrRef, TipPtrSRef, TipPtrInst:
 		return TipKindPtr
 	case TipTypePlain, TipTypeNamed:
 		return TipKindType
@@ -119,7 +120,7 @@ func (t Tip) Kind() TipKind {
 
 func (t Tip) IsValid() bool {
 	switch t {
-	case TipPtrArr, TipPtrRef, TipPtrSRef:
+	case TipPtrArr, TipPtrRef, TipPtrSRef, TipPtrInst:
 		return true
 	case TipTypePlain, TipTypeNamed:
 		return true


### PR DESCRIPTION
This change allows users to create an object oriented binding, by giving a pointer type hint of 'inst' (e.g. the 'instance object' which the given method is using).

As an example, if you were to take the vorbis binding and set the pointer hints to inst instead of ref:
```
      - {target: ^vorbis_, tips: [inst,ref,ref]}
      - {target: ^ogg_, self: arr, tips: [inst,ref]}
```

and add this to the rules section:
```
    function:
      - {action: replace, from: "^_comment_", to: _}
      - {action: replace, from: "^Ogg_stream" }
      - {action: replace, from: "^Ogg_sync" }
```


The bindings will be object oriented. As an example,
```
func CommentAddTag(vc *Comment, tag string, contents string) {...}
```

Becomes:
```
func (vc *Comment) AddTag(tag string, contents string) {...}
```

