### PR TITLE
Always output forward slashes in generate comments.

### DIFF
--- a/generator/gen_const.go
+++ b/generator/gen_const.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"path/filepath"
 
 	tl "github.com/xlab/c-for-go/translator"
 )
@@ -19,7 +20,7 @@ func (gen *Generator) writeDefinesGroup(wr io.Writer, defines []*tl.CDecl) (n in
 			continue
 		}
 		fmt.Fprintf(wr, "// %s as defined in %s\n", name,
-			gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos))
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos)))
 
 		if decl.Value != nil {
 			fmt.Fprintf(wr, "%s = %v", name, decl.Value)
@@ -41,7 +42,7 @@ func (gen *Generator) writeConstDeclaration(wr io.Writer, decl *tl.CDecl) {
 		return
 	}
 	fmt.Fprintf(wr, "// %s as declared in %s\n", declName,
-		gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos))
+		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos)))
 	goSpec := gen.tr.TranslateSpec(decl.Spec)
 
 	if decl.Value != nil {
@@ -68,11 +69,11 @@ func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSee
 	if hasType {
 		enumType := gen.tr.TranslateSpec(&spec.Type)
 		fmt.Fprintf(wr, "// %s as declared in %s\n", typeName,
-			gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos))
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos)))
 		fmt.Fprintf(wr, "type %s %s\n", typeName, enumType)
 		writeSpace(wr, 1)
 		fmt.Fprintf(wr, "// %s enumeration from %s\n", typeName,
-			gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos))
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos)))
 	}
 	writeStartConst(wr)
 	for i, m := range spec.Members {
@@ -89,7 +90,7 @@ func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSee
 		}
 		if !hasType {
 			fmt.Fprintf(wr, "// %s as declared in %s\n", mName,
-				gen.tr.SrcLocation(tl.TargetConst, m.Name, m.Pos))
+				filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, m.Name, m.Pos)))
 		}
 		switch {
 		case m.Value != nil:
@@ -131,21 +132,21 @@ func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[str
 	tagName := gen.tr.TransformName(tl.TargetType, decl.Spec.GetBase())
 	enumType := gen.tr.TranslateSpec(&spec.Type)
 	fmt.Fprintf(wr, "// %s as declared in %s\n", tagName,
-		gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos))
+		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos)))
 	fmt.Fprintf(wr, "type %s %s\n", tagName, enumType)
 	writeSpace(wr, 1)
 	if isTypedef {
 		if !bytes.Equal(tagName, declName) && len(declName) > 0 {
 			// alias type decl name to the tag
 			fmt.Fprintf(wr, "// %s as declared in %s\n", declName,
-				gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos))
+				filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos)))
 			fmt.Fprintf(wr, "type %s %s", declName, tagName)
 			writeSpace(wr, 1)
 		}
 	}
 
 	fmt.Fprintf(wr, "// %s enumeration from %s\n", tagName,
-		gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos))
+		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Pos)))
 	writeStartConst(wr)
 	for i, m := range spec.Members {
 		if !gen.tr.IsAcceptableName(tl.TargetConst, m.Name) {

--- a/generator/gen_declares.go
+++ b/generator/gen_declares.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 
 	tl "github.com/xlab/c-for-go/translator"
 )
@@ -82,7 +83,7 @@ func (gen *Generator) writeFunctionDeclaration(wr io.Writer, decl *tl.CDecl,
 		goName = gen.tr.TransformName(tl.TargetFunction, "new_"+cName, public)
 	}
 	fmt.Fprintf(wr, "// %s function as declared in %s\n", goName,
-		gen.tr.SrcLocation(tl.TargetFunction, decl.Name, decl.Pos))
+		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetFunction, decl.Name, decl.Pos)))
 	fmt.Fprintf(wr, "func")
 	gen.writeInstanceObjectParam(wr, cName, decl.Spec)
 	fmt.Fprintf(wr, " %s", goName)

--- a/generator/gen_typedef.go
+++ b/generator/gen_typedef.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 
 	tl "github.com/xlab/c-for-go/translator"
 )
@@ -16,7 +17,7 @@ func (gen *Generator) writeTypeTypedef(wr io.Writer, decl *tl.CDecl, seenNames m
 		seenNames[string(goTypeName)] = true
 	}
 	fmt.Fprintf(wr, "// %s type as declared in %s\n", goTypeName,
-		gen.tr.SrcLocation(tl.TargetType, decl.Name, decl.Pos))
+		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetType, decl.Name, decl.Pos)))
 	fmt.Fprintf(wr, "type %s %s", goTypeName, goSpec.UnderlyingString())
 	writeSpace(wr, 1)
 }
@@ -30,7 +31,7 @@ func (gen *Generator) writeEnumTypedef(wr io.Writer, decl *tl.CDecl) {
 	typeRef := gen.tr.TranslateSpec(decl.Spec).UnderlyingString()
 	if typeName := string(goName); typeName != typeRef {
 		fmt.Fprintf(wr, "// %s as declared in %s\n", goName,
-			gen.tr.SrcLocation(tl.TargetConst, cName, decl.Pos))
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, cName, decl.Pos)))
 		fmt.Fprintf(wr, "type %s %s", goName, typeRef)
 		writeSpace(wr, 1)
 	}
@@ -69,7 +70,7 @@ func (gen *Generator) writeFunctionTypedef(wr io.Writer, decl *tl.CDecl, seenNam
 	goSpec := gen.tr.TranslateSpec(funcSpec, ptrTipRx.Self(), typeTipRx.Self())
 	goSpec.Raw = "" // not used in func typedef
 	fmt.Fprintf(wr, "// %s type as declared in %s\n", goFuncName,
-		gen.tr.SrcLocation(tl.TargetFunction, decl.Name, decl.Pos))
+		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetFunction, decl.Name, decl.Pos)))
 	fmt.Fprintf(wr, "type %s %s", goFuncName, goSpec)
 	gen.writeFunctionParams(wr, decl.Name, decl.Spec)
 	if len(returnRef) > 0 {
@@ -105,7 +106,7 @@ func (gen *Generator) writeStructTypedef(wr io.Writer, decl *tl.CDecl, raw bool,
 	if raw || !decl.Spec.IsComplete() {
 		// opaque struct
 		fmt.Fprintf(wr, "// %s as declared in %s\n", goName,
-			gen.tr.SrcLocation(tl.TargetType, cName, decl.Pos))
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetType, cName, decl.Pos)))
 		fmt.Fprintf(wr, "type %s C.%s", goName, decl.Spec.CGoName())
 		writeSpace(wr, 1)
 		for _, helper := range gen.getRawStructHelpers(goName, cName, decl.Spec) {
@@ -115,7 +116,7 @@ func (gen *Generator) writeStructTypedef(wr io.Writer, decl *tl.CDecl, raw bool,
 	}
 
 	fmt.Fprintf(wr, "// %s as declared in %s\n", goName,
-		gen.tr.SrcLocation(tl.TargetType, cName, decl.Pos))
+		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetType, cName, decl.Pos)))
 	fmt.Fprintf(wr, "type %s struct {", goName)
 	writeSpace(wr, 1)
 	gen.submitHelper(cgoAllocMap)
@@ -137,7 +138,7 @@ func (gen *Generator) writeUnionTypedef(wr io.Writer, decl *tl.CDecl) {
 
 	if typeName := string(goName); typeName != typeRef {
 		fmt.Fprintf(wr, "// %s as declared in %s\n", goName,
-			gen.tr.SrcLocation(tl.TargetType, cName, decl.Pos))
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetType, cName, decl.Pos)))
 		fmt.Fprintf(wr, "const sizeof%s = unsafe.Sizeof(C.%s{})\n", goName, decl.Spec.CGoName())
 		fmt.Fprintf(wr, "type %s [sizeof%s]byte\n", goName, goName)
 		writeSpace(wr, 1)


### PR DESCRIPTION
Previously, the generator used OS-specific path separators in the
generated comments. This resulted in spurious changes in the generated
files when running c-for-go on macOS/Linux vs Windows in the same
project.