### PR TITLE
Fix parse error for empty constants

### DIFF
--- a/generator/gen_const.go
+++ b/generator/gen_const.go
@@ -27,7 +27,8 @@ func (gen *Generator) writeDefinesGroup(wr io.Writer, defines []*tl.CDecl) (n in
 		} else if len(decl.Expression) > 0 {
 			fmt.Fprintf(wr, "%s = %s", name, decl.Expression)
 		} else {
-			fmt.Fprint(wr, name)
+			// In this case, it's nil or the expression is zero length.
+			// fmt.Fprint(wr, name)
 		}
 		writeSpace(wr, 1)
 		n++


### PR DESCRIPTION
When an empty macro definition is encountered, such as:

```c
#define FOO
```

c-for-go would generate a constant whose name was equal to the printed
representation of `name`, which is a `[]byte`. So you would see
something like `[1 2 3 4 5]` (except ascii values) appearing in a
`go` source where an IDENT was expected.

Instead, drop it, since a const without a value isn't a very interesting const.