### PR TITLE
use explicit double-\n to avoid golint warning

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func init() {
 	flag.Usage = func() {
 		fmt.Println(logo)
 		fmt.Printf("Usage: %s package1.yml [package2.yml] ...\n", os.Args[0])
-		fmt.Println("See https://github.com/xlab/c-for-go for examples and documentation.\n")
+		fmt.Printf("See https://github.com/xlab/c-for-go for examples and documentation.\n\n")
 		fmt.Println("Options:")
 		flag.PrintDefaults()
 	}


### PR DESCRIPTION
Attempting to run `go test` results in:

```
[schwarzgerat](0) $ go test
# github.com/xlab/c-for-go
./main.go:39:3: Println arg list ends with redundant newline
[schwarzgerat](2) $
```

I assume the double-linebreak is desired, and have thus made it explicit with `Printf()`. If it was inadvertent, anyone can kill the extra `\n`, or kill both and take it back to `Println()`.