### PR TITLE
Check that generator is successfully created before using

### DIFF
--- a/process.go
+++ b/process.go
@@ -96,10 +96,11 @@ func NewProcess(configPath, outputPath string) (*Process, error) {
 	// begin generation
 	pkg := filepath.Base(cfg.Generator.PackageName)
 	gen, err := generator.New(pkg, cfg.Generator, tl)
-	gen.SetMaxMemory(generator.NewMemSpec(*maxMem))
 	if err != nil {
 		return nil, err
 	}
+	gen.SetMaxMemory(generator.NewMemSpec(*maxMem))
+
 	if *nostamp {
 		gen.DisableTimestamps()
 	}


### PR DESCRIPTION
This is just a simple little fix. I ran into this when I had misspelled `PackageName` in the yaml file. When the key was missing, the generator was not created and resulted in a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x5ff014]

goroutine 1 [running]:
github.com/xlab/c-for-go/generator.(*Generator).SetMaxMemory(0x0, 0x7439f5, 0xa)
        /home/spox/Projects/xlab/c-for-go/generator/generator.go:509 +0xb4
main.NewProcess(0x7ffdb591a37e, 0x9, 0x7ffdb591a375, 0x8, 0xc0000b6930, 0xc000099140, 0x42aad800)
        /home/spox/Projects/xlab/c-for-go/process.go:99 +0x409
main.main()
        /home/spox/Projects/xlab/c-for-go/main.go:79 +0x1c5
```

This just moves the error check prior to the usage of the generator which results in the expected behavior:

```
[ERR] no package name provided
```