### PR TITLE
add support for int128 and uint128 types

### DIFF
--- a/translator/ast_walker.go
+++ b/translator/ast_walker.go
@@ -349,10 +349,17 @@ func (t *Translator) typeSpec(typ cc.Type, name string, deep int, isConst bool, 
 	case cc.UInt:
 		spec.Base = "int"
 		spec.Unsigned = true
+	case cc.Int128:
+		spec.Base = "int"
+		spec.Long = true
 	case cc.Long:
 		spec.Base = "int"
 		spec.Long = true
 	case cc.ULong:
+		spec.Base = "int"
+		spec.Long = true
+		spec.Unsigned = true
+	case cc.UInt128:
 		spec.Base = "int"
 		spec.Long = true
 		spec.Unsigned = true


### PR DESCRIPTION
I had issues when trying c-for-go on a project until I added support for the int128/uint128 types