### PR TITLE
A few changes needed to support go-libvirt

### DIFF
--- a/generator/gen_const.go
+++ b/generator/gen_const.go
@@ -69,6 +69,11 @@ func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSee
 	spec := decl.Spec.(*tl.CEnumSpec)
 	if hasType {
 		enumType := gen.tr.TranslateSpec(&spec.Type)
+		if tips, ok := gen.tr.TypeTipRx(tl.TipScopeEnum, string(typeName)); ok {
+			if tips.HasTip(tl.TipTypeUnsigned) {
+				enumType.Unsigned = true
+			}
+		}
 		fmt.Fprintf(wr, "// %s as declared in %s\n", typeName,
 			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
 		fmt.Fprintf(wr, "type %s %s\n", typeName, enumType)
@@ -132,6 +137,11 @@ func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[str
 	spec := decl.Spec.(*tl.CEnumSpec)
 	tagName := gen.tr.TransformName(tl.TargetType, decl.Spec.GetBase())
 	enumType := gen.tr.TranslateSpec(&spec.Type)
+	if tips, ok := gen.tr.TypeTipRx(tl.TipScopeEnum, string(tagName)); ok {
+		if tips.HasTip(tl.TipTypeUnsigned) {
+			enumType.Unsigned = true
+		}
+	}
 	fmt.Fprintf(wr, "// %s as declared in %s\n", tagName,
 		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
 	fmt.Fprintf(wr, "type %s %s\n", tagName, enumType)

--- a/translator/rules.go
+++ b/translator/rules.go
@@ -86,15 +86,16 @@ const (
 type Tip string
 
 const (
-	TipPtrSRef    Tip = "sref"
-	TipPtrRef     Tip = "ref"
-	TipPtrArr     Tip = "arr"
-	TipPtrInst    Tip = "inst"
-	TipMemRaw     Tip = "raw"
-	TipTypeNamed  Tip = "named"
-	TipTypePlain  Tip = "plain"
-	TipTypeString Tip = "string"
-	NoTip         Tip = ""
+	TipPtrSRef      Tip = "sref"
+	TipPtrRef       Tip = "ref"
+	TipPtrArr       Tip = "arr"
+	TipPtrInst      Tip = "inst"
+	TipMemRaw       Tip = "raw"
+	TipTypeNamed    Tip = "named"
+	TipTypePlain    Tip = "plain"
+	TipTypeString   Tip = "string"
+	TipTypeUnsigned Tip = "unsigned"
+	NoTip           Tip = ""
 )
 
 type TipKind string
@@ -110,7 +111,7 @@ func (t Tip) Kind() TipKind {
 	switch t {
 	case TipPtrArr, TipPtrRef, TipPtrSRef, TipPtrInst:
 		return TipKindPtr
-	case TipTypePlain, TipTypeNamed, TipTypeString:
+	case TipTypePlain, TipTypeNamed, TipTypeString, TipTypeUnsigned:
 		return TipKindType
 	case TipMemRaw:
 		return TipKindMem
@@ -126,6 +127,8 @@ func (t Tip) IsValid() bool {
 	case TipTypePlain, TipTypeNamed, TipTypeString:
 		return true
 	case TipMemRaw:
+		return true
+	case TipTypeUnsigned:
 		return true
 	default:
 		return false
@@ -145,6 +148,7 @@ const (
 	TipScopeAny      TipScope = "any"
 	TipScopeStruct   TipScope = "struct"
 	TipScopeType     TipScope = "type"
+	TipScopeEnum     TipScope = "enum"
 	TipScopeFunction TipScope = "function"
 )
 

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -71,6 +71,15 @@ func (t TipSpecRx) TipAt(i int) Tip {
 	return t.Default
 }
 
+func (t TipSpecRx) HasTip(q Tip) bool {
+	for _, tip := range t.tips {
+		if tip.IsValid() && tip == q {
+			return true
+		}
+	}
+	return false
+}
+
 func (t TipSpecRx) Self() Tip {
 	if t.self.IsValid() {
 		return t.self


### PR DESCRIPTION
At DigitalOcean, we are using `c-for-go` for our [`go-libvirt`](https://github.com/digitalocean/go-libvirt) project.

Two breaking changes have occurred recently, which are preventing us from using `c-for-go` to generate the necessary constants:

(1) In `libvirt` itself, header files were switched from using double-quotes (`#include "foo.h"`) to using brackets (`#include <foo.h>`). Because these were self-referencing headers (intended for eventual placement on the system include path on the target system), this resulted in the inability of `c-for-go` to find `libvirt`'s own headers. We resolved this by adding the ability to configure the system include path, such (in our case) by specifying `SysIncludePaths: [./lv_source/include, ./lv_source/build/include]` in the configuration.

(2) In `c-for-go`, an update of the `cc` dependency to `v4` caused a change in the way enums were handled. For context, although `c-for-go` correctly treats C enumerations as being of type `int`, the `libvirt` code contains two enum usages where their values are used for bit fields, and explicitly declared as unsigned 32-bit values. This causes `c-for-go` to generate incorrect code (because the integer value `2147483648`, which comes from [`1u << 31`](https://github.com/libvirt/libvirt/blob/5f6025945bf0f98debcd4ad8cf064e9cadca1cc9/include/libvirt/libvirt-nodedev.h#L91), could not fit into a signed 32-bit field). This was resolved by adding the concept of `enum` type tips and `unsigned` type tips (`TipTypeUnsigned`), such as (in our case) by declaring the following in the configuration:

```yml
    TypeTips:
        enum:
            - { target: "ConnectGetAllDomainStatsFlags", tips: [ unsigned ] }
            - { target: "ConnectListAllNodeDeviceFlags", tips: [ unsigned ] }
```

We have been testing these changes successfully in our [`digitalocean-labs/c-for-go`](https://github.com/digitalocean-labs/c-for-go) fork, and hope you will consider applying them to the official version.