### PR TITLE
Feat symbol validation

### DIFF
--- a/generator/gen_bindings.go
+++ b/generator/gen_bindings.go
@@ -1020,6 +1020,12 @@ func (gen *Generator) submitHelper(h *Helper) {
 
 func (gen *Generator) writeFunctionBody(wr io.Writer, decl *tl.CDecl) {
 	writeStartFuncBody(wr)
+
+	validateFunc, validateRet, matched := gen.tr.GetLibrarySymbolValidation(decl.Name)
+	if matched {
+		writeValidation(wr, validateFunc, decl.Name, validateRet)
+	}
+
 	wr2 := new(reverseBuffer)
 	from, to := gen.createProxies(decl.Name, decl.Spec)
 	for _, proxy := range from {
@@ -1129,7 +1135,7 @@ var (
 			m   map[unsafe.Pointer]struct{}
 		}
 
-		var cgoAllocsUnknown = new(cgoAllocMap) 
+		var cgoAllocsUnknown = new(cgoAllocMap)
 
 		func (a *cgoAllocMap) Add(ptr unsafe.Pointer) {
 			a.mux.Lock()

--- a/generator/gen_common.go
+++ b/generator/gen_common.go
@@ -8,6 +8,8 @@ import (
 	tl "github.com/xlab/c-for-go/translator"
 )
 
+const validationTemplate = "if %s(\"%s\") != nil { \n	return %s \n}\n"
+
 var (
 	skipName    = []byte("_")
 	skipNameStr = "_"
@@ -190,4 +192,8 @@ func writeSpace(wr io.Writer, n int) {
 
 func writeError(wr io.Writer, err error) {
 	fmt.Fprintf(wr, "// error: %v\n", err)
+}
+
+func writeValidation(wr io.Writer, validateFunc, funcName, retStr string) {
+	fmt.Fprintf(wr, validationTemplate, validateFunc, funcName, retStr)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/xlab/c-for-go
 go 1.17
 
 require (
+	github.com/dlclark/regexp2 v1.11.0
 	github.com/stretchr/testify v1.6.1
 	github.com/tj/go-spin v1.1.0
 	github.com/xlab/pkgconfig v0.0.0-20170226114623-cea12a0fd245

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=

--- a/translator/rules.go
+++ b/translator/rules.go
@@ -1,10 +1,28 @@
 package translator
 
+import (
+	"github.com/dlclark/regexp2"
+)
+
 type Rules map[RuleTarget][]RuleSpec
 type ConstRules map[ConstScope]ConstRule
 type PtrTips map[TipScope][]TipSpec
 type TypeTips map[TipScope][]TipSpec
 type MemTips []TipSpec
+
+type Validations []ValidationSpec
+
+type ValidationSpec struct {
+	ValidateFunc string
+	Ret          string
+	MatchedFunc  string
+}
+
+func (v ValidationSpec) MatchFunc(name string) bool {
+	reg := regexp2.MustCompile(v.MatchedFunc, 0)
+	matched, _ := reg.MatchString(name)
+	return matched
+}
 
 type RuleSpec struct {
 	From, To  string


### PR DESCRIPTION
#165 

# How to use
yaml file will add  a `Validations` filed in `TRANSLATOR`:
```diff
---
GENERATOR:
  PackageName: device
  PackageDescription: "Package Device bindings"
  PackageLicense: |-
  Includes: ["device.h", "device_internal.h"]
  FlagGroups:
    - {name: "LDFLAGS", flags: ["-ldevice"]}
  Options:
    SafeStrings: true
PARSER:
  IncludePaths: ["."]
  SourcesPaths: ["device.h", "device_internal.h"]
TRANSLATOR:
  ....
+  Validations:
+     - validatefunc: libdevice.Lookup
+       ret: ERROR_NOT_SUPPORTED
+       matchedfunc: ^(?!.*deviceErrorString).*$
+     - validatefunc: libdevice.Lookup
+        ret: ERROR_NOT_SUPPORTED_STRING
+        matchedfunc: ^deviceErrorString
```
and the generated go function codes as follows:
```diff
// deviceErrorString function as declared in device/device.h
func deviceErrorString(Result Return) string {
+       if libdevice.Lookup("deviceGetMode") != nil {
+		return ERROR_NOT_SUPPORTED_STRING
+	}
	cResult, cResultAllocMap := (C.DeviceReturn)(Result), cgoAllocsUnknown
	__ret := C.deviceErrorString(cResult)
	runtime.KeepAlive(cResultAllocMap)
	__v := packPCharString(__ret)
	return __v
}

// deviceGetMode function as declared in device/device.h
func deviceGetMode(Device *Device, Mode Mode) Return {
+	if libdevice.Lookup("deviceGetMode") != nil {
+		return ERROR_NOT_SUPPORTED
+	}
	cDevice, cDeviceAllocMap := (*C.Device)(unsafe.Pointer(Device)), cgoAllocsUnknown
	cMode, cModeAllocMap := (C.Mode)(Mode), cgoAllocsUnknown
	__ret := C.deviceGetMode(cDevice, cMode)
	runtime.KeepAlive(cModeAllocMap)
	runtime.KeepAlive(cDeviceAllocMap)
	__v := (Return)(__ret)
	return __v
}
```
- `validatefunc` field is used to specify the lookup function which defined bu user.
- `ret` filed is used to specify the ret value which defined by user.
- `matchedfunc` field is used to specify a full-featured regex to match functions or skip functions.