### PR TITLE
fix for ast_walker test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+.vscode
 .DS_Store
 /tmp/
 c-for-go


### PR DESCRIPTION
In file `ast_walker_test.go`, a test `TestFunctionStringReturn` does not pass on the line with `returnSpec.IsConst()`.
Fixed with an additional check.