### PR TITLE
fix duplicate types created by aliases

### DIFF
--- a/generator/gen_const.go
+++ b/generator/gen_const.go
@@ -57,7 +57,7 @@ func (gen *Generator) writeConstDeclaration(wr io.Writer, decl *tl.CDecl) {
 	fmt.Fprintf(wr, "var %s %s", declName, goSpec)
 }
 
-func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSeen map[string]bool) {
+func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSeen map[string]bool, typesSeen map[string]bool) {
 	var typeName []byte
 	var hasType bool
 	if decl.IsTypedef {
@@ -68,6 +68,10 @@ func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSee
 
 	spec := decl.Spec.(*tl.CEnumSpec)
 	if hasType {
+		if typesSeen[string(typeName)] {
+			return
+		}
+		typesSeen[string(typeName)] = true
 		enumType := gen.tr.TranslateSpec(&spec.Type)
 		if tips, ok := gen.tr.TypeTipRx(tl.TipScopeEnum, string(typeName)); ok {
 			if tips.HasTip(tl.TipTypeUnsigned) {
@@ -125,7 +129,7 @@ func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSee
 	writeSpace(wr, 1)
 }
 
-func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[string]bool) {
+func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[string]bool, typesSeen map[string]bool) {
 	var declName []byte
 	var isTypedef bool
 	if decl.IsTypedef {
@@ -142,17 +146,23 @@ func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[str
 			enumType.Unsigned = true
 		}
 	}
-	fmt.Fprintf(wr, "// %s as declared in %s\n", tagName,
-		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
-	fmt.Fprintf(wr, "type %s %s\n", tagName, enumType)
-	writeSpace(wr, 1)
+	if !typesSeen[string(tagName)] {
+		typesSeen[string(tagName)] = true
+		fmt.Fprintf(wr, "// %s as declared in %s\n", tagName,
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
+		fmt.Fprintf(wr, "type %s %s\n", tagName, enumType)
+		writeSpace(wr, 1)
+	}
 	if isTypedef {
 		if !bytes.Equal(tagName, declName) && len(declName) > 0 {
-			// alias type decl name to the tag
-			fmt.Fprintf(wr, "// %s as declared in %s\n", declName,
-				filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
-			fmt.Fprintf(wr, "type %s %s", declName, tagName)
-			writeSpace(wr, 1)
+			if !typesSeen[string(declName)] {
+				typesSeen[string(declName)] = true
+				// alias type decl name to the tag
+				fmt.Fprintf(wr, "// %s as declared in %s\n", declName,
+					filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
+				fmt.Fprintf(wr, "type %s %s", declName, tagName)
+				writeSpace(wr, 1)
+			}
 		}
 	}
 

--- a/generator/gen_const.go
+++ b/generator/gen_const.go
@@ -82,10 +82,8 @@ func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSee
 			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
 		fmt.Fprintf(wr, "type %s %s\n", typeName, enumType)
 		writeSpace(wr, 1)
-		fmt.Fprintf(wr, "// %s enumeration from %s\n", typeName,
-			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
 	}
-	writeStartConst(wr)
+	var constBuf bytes.Buffer
 	for i, m := range spec.Members {
 		if !gen.tr.IsAcceptableName(tl.TargetConst, m.Name) {
 			continue
@@ -99,34 +97,42 @@ func (gen *Generator) expandEnumAnonymous(wr io.Writer, decl *tl.CDecl, namesSee
 			namesSeen[string(mName)] = true
 		}
 		if !hasType {
-			fmt.Fprintf(wr, "// %s as declared in %s\n", mName,
+			fmt.Fprintf(&constBuf, "// %s as declared in %s\n", mName,
 				filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, m.Name, m.Position)))
 		}
 		switch {
 		case m.Value != nil:
 			if hasType {
-				fmt.Fprintf(wr, "%s %s = %s\n", mName, typeName, iotaOnZero(i, m.Value))
+				fmt.Fprintf(&constBuf, "%s %s = %s\n", mName, typeName, iotaOnZero(i, m.Value))
 				continue
 			}
-			fmt.Fprintf(wr, "%s = %s\n", mName, iotaOnZero(i, m.Value))
+			fmt.Fprintf(&constBuf, "%s = %s\n", mName, iotaOnZero(i, m.Value))
 		case len(m.Expression) > 0:
 			if hasType {
-				fmt.Fprintf(wr, "%s %s = %s\n", mName, typeName, iotaOnZero(i, m.Expression))
+				fmt.Fprintf(&constBuf, "%s %s = %s\n", mName, typeName, iotaOnZero(i, m.Expression))
 				continue
 			}
-			fmt.Fprintf(wr, "%s = %s\n", mName, iotaOnZero(i, m.Expression))
+			fmt.Fprintf(&constBuf, "%s = %s\n", mName, iotaOnZero(i, m.Expression))
 		default:
 			if i == 0 && hasType {
-				fmt.Fprintf(wr, "%s %s = iota\n", mName, typeName)
+				fmt.Fprintf(&constBuf, "%s %s = iota\n", mName, typeName)
 				continue
 			} else if i == 0 {
-				fmt.Fprintf(wr, "%s = iota\n", mName)
+				fmt.Fprintf(&constBuf, "%s = iota\n", mName)
 			}
-			fmt.Fprintf(wr, "%s\n", mName)
+			fmt.Fprintf(&constBuf, "%s\n", mName)
 		}
 	}
-	writeEndConst(wr)
-	writeSpace(wr, 1)
+	if constBuf.Len() > 0 {
+		if hasType {
+			fmt.Fprintf(wr, "// %s enumeration from %s\n", typeName,
+				filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
+		}
+		writeStartConst(wr)
+		constBuf.WriteTo(wr)
+		writeEndConst(wr)
+		writeSpace(wr, 1)
+	}
 }
 
 func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[string]bool, typesSeen map[string]bool) {
@@ -166,9 +172,7 @@ func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[str
 		}
 	}
 
-	fmt.Fprintf(wr, "// %s enumeration from %s\n", tagName,
-		filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
-	writeStartConst(wr)
+	var constBuf bytes.Buffer
 	for i, m := range spec.Members {
 		if !gen.tr.IsAcceptableName(tl.TargetConst, m.Name) {
 			continue
@@ -183,19 +187,25 @@ func (gen *Generator) expandEnum(wr io.Writer, decl *tl.CDecl, namesSeen map[str
 		}
 		switch {
 		case m.Value != nil:
-			fmt.Fprintf(wr, "%s %s = %v\n", mName, declName, iotaOnZero(i, m.Value))
+			fmt.Fprintf(&constBuf, "%s %s = %v\n", mName, declName, iotaOnZero(i, m.Value))
 		case len(m.Expression) > 0:
-			fmt.Fprintf(wr, "%s %s = %v\n", mName, declName, iotaOnZero(i, m.Expression))
+			fmt.Fprintf(&constBuf, "%s %s = %v\n", mName, declName, iotaOnZero(i, m.Expression))
 		default:
 			if i == 0 {
-				fmt.Fprintf(wr, "%s %s = iota\n", mName, declName)
+				fmt.Fprintf(&constBuf, "%s %s = iota\n", mName, declName)
 				continue
 			}
-			fmt.Fprintf(wr, "%s\n", mName)
+			fmt.Fprintf(&constBuf, "%s\n", mName)
 		}
 	}
-	writeEndConst(wr)
-	writeSpace(wr, 1)
+	if constBuf.Len() > 0 {
+		fmt.Fprintf(wr, "// %s enumeration from %s\n", tagName,
+			filepath.ToSlash(gen.tr.SrcLocation(tl.TargetConst, decl.Name, decl.Position)))
+		writeStartConst(wr)
+		constBuf.WriteTo(wr)
+		writeEndConst(wr)
+		writeSpace(wr, 1)
+	}
 }
 
 func iotaOnZero(i int, v interface{}) string {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -92,16 +92,17 @@ func (gen *Generator) WriteConst(wr io.Writer) int {
 	writeSpace(wr, 1)
 	tagsSeen := make(map[string]bool)
 	namesSeen := make(map[string]bool)
+	typesSeen := make(map[string]bool)
 
 	gen.submitHelper(cgoGenTag)
 	expandEnum := func(decl *tl.CDecl) bool {
 		if tag := decl.Spec.GetTag(); len(tag) == 0 {
-			gen.expandEnumAnonymous(wr, decl, namesSeen)
+			gen.expandEnumAnonymous(wr, decl, namesSeen, typesSeen)
 			return true
 		} else if tagsSeen[tag] {
 			return false
 		} else {
-			gen.expandEnum(wr, decl, namesSeen)
+			gen.expandEnum(wr, decl, namesSeen, typesSeen)
 			if decl.Spec.IsComplete() {
 				tagsSeen[tag] = true
 			}


### PR DESCRIPTION
Aliases for types creating duplicity definitions. This patch fixes it.

The first commit stops creating definitions, but it still generates comments with empty "const".
The second one stops creating comments and empty "const" definitions.
This way, it's better to read and understand, but of course, it's ok to squash it.

Tested on Vulkan API headers v1.3.241.